### PR TITLE
embedded-io compat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,6 +662,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "embedded-io-async"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff09972d4073aa8c299395be75161d582e7629cd663171d62af73c8d50dba3f"
+dependencies = [
+ "embedded-io",
+]
+
+[[package]]
+name = "embedded-nal"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56a28be191a992f28f178ec338a0bf02f63d7803244add736d026a471e6ed77"
+dependencies = [
+ "nb",
+]
+
+[[package]]
+name = "embedded-nal-async"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76959917cd2b86f40a98c28dd5624eddd1fa69d746241c8257eac428d83cb211"
+dependencies = [
+ "embedded-io-async",
+ "embedded-nal",
+]
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +1688,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "nb"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "nix"
@@ -3450,6 +3490,8 @@ dependencies = [
  "bitflags",
  "bytes",
  "ed25519",
+ "embedded-io-async",
+ "embedded-nal-async",
  "flume",
  "futures",
  "getrandom 0.2.16",

--- a/server/src/handle/wisp/twisp.rs
+++ b/server/src/handle/wisp/twisp.rs
@@ -15,7 +15,7 @@ use wisp_mux::{
 		ProtocolExtensionBuilder,
 	},
 	stream::{MuxStreamAsyncRead, MuxStreamAsyncWrite},
-	ws::{WebSocketRead, WebSocketWrite},
+	ws::{TransportRead as WebSocketRead, TransportWrite as WebSocketWrite},
 	WispError,
 };
 

--- a/wisp/Cargo.toml
+++ b/wisp/Cargo.toml
@@ -18,6 +18,8 @@ async-trait = "0.1.85"
 bitflags = { version = "2.6.0", optional = true }
 bytes = "1.9.0"
 ed25519 = { version = "2.2.3", optional = true, features = ["std", "alloc"] }
+embedded-io-async = { version = "0.6.1", optional = true }
+embedded-nal-async = { version = "0.8.0", optional = true }
 flume = "0.11.1"
 futures = { version = "0.3.31", default-features = false, features = ["std", "async-await"] }
 getrandom = { version = "0.2.15", optional = true }
@@ -36,6 +38,8 @@ certificate = ["dep:getrandom", "dep:ed25519", "dep:bitflags"]
 wasm = ["getrandom/js"]
 tokio-websockets = ["dep:tokio-websockets", "dep:tokio"]
 tokio-tungstenite = ["dep:tokio-tungstenite", "dep:tokio"]
+embedded-io-async = ["dep:embedded-io-async","embedded-io-async/std"]
+embedded-nal-async = ["dep:embedded-nal-async","embedded-io-async"]
 
 [dev-dependencies]
 tokio = { version = "1.42.0", features = ["macros", "rt", "time"] }

--- a/wisp/src/mux/client.rs
+++ b/wisp/src/mux/client.rs
@@ -179,3 +179,29 @@ impl<W: TransportWrite> Multiplexor<ClientImpl, W> {
 		rx.await.map_err(|_| WispError::MuxMessageFailedToRecv)?
 	}
 }
+#[cfg(feature = "embedded-nal-async")]
+const _: () = {
+	use crate::stream::MuxStreamAsyncRW;
+
+	impl<W: TransportWrite> embedded_nal_async::TcpConnect for Multiplexor<ClientImpl, W> {
+		type Error = std::io::Error;
+
+		type Connection<'a>
+			= MuxStreamAsyncRW<W>
+		where
+			Self: 'a;
+
+		async fn connect<'a>(
+			&'a self,
+			remote: std::net::SocketAddr,
+		) -> Result<Self::Connection<'a>, Self::Error> {
+			use std::io::ErrorKind;
+
+			let mut stream = self
+				.new_stream(StreamType::Tcp, remote.ip().to_string(), remote.port())
+				.await
+				.map_err(|e| std::io::Error::new(ErrorKind::Other, e))?;
+			Ok(stream.into_async_rw())
+		}
+	}
+};

--- a/wisp/src/stream/compat.rs
+++ b/wisp/src/stream/compat.rs
@@ -73,6 +73,22 @@ impl<W: TransportWrite> AsyncBufRead for MuxStreamAsyncRead<W> {
 	}
 }
 
+#[cfg(feature = "embedded-io-async")]
+const _: () = {
+	use embedded_io_async::ErrorType;
+
+	impl<W: TransportWrite> ErrorType for MuxStreamAsyncRead<W> {
+		type Error = std::io::Error;
+	}
+	impl<W: TransportWrite> embedded_io_async::Read for MuxStreamAsyncRead<W> {
+		async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+			use futures::AsyncReadExt;
+
+			AsyncReadExt::read(self, buf).await
+		}
+	}
+};
+
 pub struct MuxStreamAsyncWrite<W: TransportWrite> {
 	inner: flume::r#async::SendSink<'static, WsEvent<W>>,
 	write: LockedWebSocketWrite<W>,
@@ -159,6 +175,22 @@ impl<W: TransportWrite> AsyncWrite for MuxStreamAsyncWrite<W> {
 	}
 }
 
+#[cfg(feature = "embedded-io-async")]
+const _: () = {
+	use embedded_io_async::ErrorType;
+
+	impl<W: TransportWrite> ErrorType for MuxStreamAsyncWrite<W> {
+		type Error = std::io::Error;
+	}
+	impl<W: TransportWrite> embedded_io_async::Write for MuxStreamAsyncWrite<W> {
+		async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+			use futures::AsyncWriteExt;
+
+			AsyncWriteExt::write(self, buf).await
+		}
+	}
+};
+
 #[pin_project]
 pub struct MuxStreamAsyncRW<W: TransportWrite> {
 	#[pin]
@@ -238,3 +270,25 @@ impl<W: TransportWrite> AsyncWrite for MuxStreamAsyncRW<W> {
 		self.project().write.poll_close(cx)
 	}
 }
+#[cfg(feature = "embedded-io-async")]
+const _: () = {
+	use embedded_io_async::ErrorType;
+
+	impl<W: TransportWrite> ErrorType for MuxStreamAsyncRW<W> {
+		type Error = std::io::Error;
+	}
+	impl<W: TransportWrite> embedded_io_async::Read for MuxStreamAsyncRW<W> {
+		async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+			use futures::AsyncReadExt;
+
+			AsyncReadExt::read(self, buf).await
+		}
+	}
+	impl<W: TransportWrite> embedded_io_async::Write for MuxStreamAsyncRW<W> {
+		async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+			use futures::AsyncWriteExt;
+
+			AsyncWriteExt::write(self, buf).await
+		}
+	}
+};


### PR DESCRIPTION
Adds compatibility with the `embedded-io-async` and `embedded-nal-async` crates and fixes a bug in Twisp