### PR TITLE
working directory agnostic scripts

### DIFF
--- a/client/build.sh
+++ b/client/build.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 shopt -s inherit_errexit
 
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 mkdir out/ || true
 rm -r pkg/ || true
 mkdir pkg/

--- a/client/publish.sh
+++ b/client/publish.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 shopt -s inherit_errexit
 
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
 export RELEASE="${RELEASE:-1}"
 
 rm -r full minimal || true


### PR DESCRIPTION
so `./client/build.sh` works the same as `cd client; ./build.sh`